### PR TITLE
fix: 接口描述改用 pre 标签保留原始格式

### DIFF
--- a/ui/default/index.html
+++ b/ui/default/index.html
@@ -297,7 +297,7 @@
                             <span id="detail-deprecated" class="hidden bg-red-100 text-red-600 px-2 py-1 rounded text-xs">已废弃</span>
                         </div>
                         <h3 id="detail-summary" class="text-xl font-semibold mb-2">接口名称</h3>
-                        <p id="detail-description" style="color: var(--text-secondary)">接口描述</p>
+                        <pre id="detail-description" style="color: var(--text-secondary)">接口描述</pre>
                     </div>
 
                     <!-- Parameters -->

--- a/ui/minimal/index.html
+++ b/ui/minimal/index.html
@@ -227,7 +227,7 @@
                             <span id="detail-deprecated" class="hidden text-red-500 text-xs">废弃</span>
                         </div>
                         <h3 id="detail-summary" class="font-medium">接口名称</h3>
-                        <p id="detail-description" class="text-sm mt-1" style="color: var(--text-secondary)">描述</p>
+                        <pre id="detail-description" class="text-sm mt-1" style="color: var(--text-secondary)">描述</pre>
                     </div>
 
                     <div class="card rounded-lg p-4">

--- a/ui/modern/index.html
+++ b/ui/modern/index.html
@@ -289,7 +289,7 @@
                             <span id="detail-deprecated" class="hidden bg-red-100 text-red-600 px-2 py-1 rounded-lg text-xs">已废弃</span>
                         </div>
                         <h3 id="detail-summary" class="text-xl font-bold mb-2">接口名称</h3>
-                        <p id="detail-description" style="color: var(--text-secondary)">接口描述</p>
+                        <pre id="detail-description" style="color: var(--text-secondary)">接口描述</pre>
                     </div>
 
                     <div class="card p-6">


### PR DESCRIPTION
## Summary
- 三个主题（default、minimal、modern）的 `detail-description` 元素从 `<p>` 改为 `<pre>`
- 修复多行接口描述被压缩为单行的问题，保留 Swagger 注释中的原始排版格式

## Test plan
- [x] 验证含多行描述的接口在三个主题下均正确显示换行
- [x] 验证单行描述的接口显示无回归